### PR TITLE
Fix cleanup of heap after an empty stats scandir

### DIFF
--- a/w_filepicker.c
+++ b/w_filepicker.c
@@ -93,7 +93,7 @@ SDL_Surface *atg_render_filepicker(const atg_element *e)
 		int nstats=scandir(f->curdir, &stats, filter_stats, sortfn);
 		if(nstats==-1)
 		{
-			while(files--)
+			while(nfiles--)
 				free(files[nfiles]);
 			free(files);
 			while(ndirs--)


### PR DESCRIPTION
The wrong variable was decremented during cleanup, which would cause
invalid pointers to be freed, potentially causing a crash.  This was
detected with the gcc 12 warning:

'free' called on a pointer to an unallocated object